### PR TITLE
将i的类型改为long，修复int溢出问题

### DIFF
--- a/src/main/java/com/github/hcsp/datatype/IntegerOverflow.java
+++ b/src/main/java/com/github/hcsp/datatype/IntegerOverflow.java
@@ -5,7 +5,7 @@ public class IntegerOverflow {
     // Fix this method to make it output "i=3000000000"
     public static void main(String[] args) {
         int 十亿 = 10_0000_0000;
-        int i = 0;
+        long i = 0L;
 
         i = i + 十亿;
         System.out.println("i=" + i);


### PR DESCRIPTION
将i的类型改为long，修复int溢出问题，通过测试